### PR TITLE
Demonstrate how a message header bit can be used for message fragmentation

### DIFF
--- a/client/internal/wsreceiver_test.go
+++ b/client/internal/wsreceiver_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -106,4 +108,36 @@ func TestServerToAgentCommandExclusive(t *testing.T) {
 	})
 	assert.Equal(t, true, calledCommand, "OnCommand should be called when a Command is specified")
 	assert.Equal(t, false, calledOnMessageConfig, "OnMessage should not be called when a Command is specified")
+}
+
+func TestDecodeMessage(t *testing.T) {
+	msgsToTest := []*protobufs.ServerToAgent{
+		{}, // Empty message
+		{
+			InstanceUid: "abcd",
+		},
+	}
+
+	// Try with and without header byte. This is only necessary until the
+	// end of grace period that ends Feb 1, 2023. After that the header is
+	// no longer optional.
+	withHeaderTests := []bool{false, true}
+
+	for _, msg := range msgsToTest {
+		for _, withHeader := range withHeaderTests {
+			bytes, err := proto.Marshal(msg)
+			require.NoError(t, err)
+
+			if withHeader {
+				// Prepend zero header byte.
+				bytes = append([]byte{0}, bytes...)
+			}
+
+			var decoded protobufs.ServerToAgent
+			err = decodeMessage(bytes, &decoded)
+			require.NoError(t, err)
+
+			assert.True(t, proto.Equal(msg, &decoded))
+		}
+	}
 }

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/binary"
 	"net"
 
 	"github.com/gorilla/websocket"
@@ -22,12 +23,39 @@ func (c wsConnection) RemoteAddr() net.Addr {
 	return c.wsConn.RemoteAddr()
 }
 
+// Message header is currently uint64 zero value.
+const msgHeader = uint64(0)
+
 func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) error {
 	bytes, err := proto.Marshal(message)
 	if err != nil {
 		return err
 	}
-	return c.wsConn.WriteMessage(websocket.BinaryMessage, bytes)
+
+	writer, err := c.wsConn.NextWriter(websocket.BinaryMessage)
+	if err != nil {
+		return err
+	}
+
+	// Encode header as a varint.
+	hdrBuf := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(hdrBuf, msgHeader)
+	hdrBuf = hdrBuf[:n]
+
+	// Write the header bytes.
+	_, err = writer.Write(hdrBuf)
+	if err != nil {
+		writer.Close()
+		return err
+	}
+
+	// Write the encoded data.
+	_, err = writer.Write(bytes)
+	if err != nil {
+		writer.Close()
+		return err
+	}
+	return writer.Close()
 }
 
 func (c wsConnection) Disconnect() error {


### PR DESCRIPTION
Demonstrate how a message header bit can be used for message fragmentation

This implements fragmenting only in the client's sending and reassembly in the
mock server's receiving.

The other directions are not implemented in this example, but will be very similar.